### PR TITLE
Convert audio_duration to float

### DIFF
--- a/itu_p1203/extractor.py
+++ b/itu_p1203/extractor.py
@@ -561,7 +561,7 @@ class Extractor(object):
 
         if has_audio:
             if "duration" in audio_info:
-                audio_duration = audio_info["duration"]
+                audio_duration = float(audio_info["duration"])
             elif "tags" in audio_info and "DURATION" in audio_info["tags"]:
                 duration_str = audio_info["tags"]["DURATION"]
                 hms, msec = duration_str.split(".")


### PR DESCRIPTION
The `Extractor` class occasionally throws `TypeError` exceptions. The reason seems to be that sometimes type of the `audio_duration` variable is `str` when read from `duration` key of `audio_info`. It seems to happen more when segment duration is lower than 1 second. This solves the issue.